### PR TITLE
Convert site to single-page scrolling section layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,23 +1,51 @@
+html {
+    scroll-behavior: smooth;
+    scroll-snap-type: y mandatory;
+}
+
 body {
     margin: 0;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-    color: #1a1a1a;
-    background: #ffffff;
+    color: #ffffff;
     line-height: 1.6;
+    background: #111;
 }
 
-/* Layout */
-.site-header {
+main {
+    position: relative;
+}
+
+.site-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
+    padding: 16px 0;
+    background: rgba(0, 0, 0, 0.18);
+    backdrop-filter: blur(2px);
+    transition: background 0.3s ease, backdrop-filter 0.3s ease, box-shadow 0.3s ease;
+}
+
+.site-nav.scrolled {
+    background: rgba(0, 0, 0, 0.48);
+    backdrop-filter: blur(8px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+}
+
+.header-inner {
+    max-width: 1200px;
+    margin: 0 auto;
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 1rem 2rem;
-    background: #F7F9FB;
+    gap: 16px;
+    padding: 0 10%;
 }
 
 .logo {
     width: auto;
 }
+
 .logo-header {
     height: 44px;
 }
@@ -26,164 +54,124 @@ body {
     height: 40px;
 }
 
-
-@media (max-width: 640px) {
-    .logo-header,
-    .logo-footer {
-        height: 32px;
-    }
-}
-
-nav a {
-    margin-left: 1.5rem;
-    text-decoration: none;
-    color: #0B1F33;
-    font-weight: 500;
-}
-
-nav a:hover {
-    color: #2FC4FF;
-}
-
-header,
-footer {
-    padding: 20px;
-    border-bottom: 1px solid #eee;
-}
-
-footer {
-    border-top: 1px solid #eee;
-    border-bottom: none;
-    text-align: center;
-    font-size: 0.9rem;
-    color: #666;
-    margin-top: 80px;
-}
-
-.footer-inner {
-    max-width: 1040px;
-    margin: 0 auto;
+nav ul {
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 8px;
-}
-
-.footer-inner p {
+    list-style: none;
+    gap: 24px;
     margin: 0;
-    font-size: 0.9rem;
-}
-
-main {
-    max-width: 1040px;
-    margin: auto;
-    padding: 80px 20px;
-}
-
-/* Header */
-.header-inner {
-    max-width: 1040px;
-    margin: auto;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.brand {
-    font-weight: 600;
-    letter-spacing: 0.04em;
+    padding: 0;
 }
 
 nav a {
-    margin-left: 24px;
+    color: #ffffff;
     text-decoration: none;
     font-weight: 500;
-    color: #0057ff;
-    cursor: pointer;
+    opacity: 0.85;
+    transition: opacity 0.2s ease;
 }
 
-nav a:hover {
-    text-decoration: underline;
+nav a:hover,
+nav a.is-active {
+    opacity: 1;
 }
 
-/* Content */
+.language-switch {
+    margin-left: auto;
+}
+
+#language-select {
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.35);
+    color: #fff;
+    font-size: 0.95rem;
+    padding: 6px 10px;
+}
+
+.section {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 96px 10% 80px;
+    box-sizing: border-box;
+    scroll-snap-align: start;
+    opacity: 0;
+    transform: translateY(40px);
+    transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+.section.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.section-home {
+    background: linear-gradient(135deg, #1f5f3f, #2e8b57);
+}
+
+.section-automation {
+    background: linear-gradient(135deg, #1b4f72, #2fc4ff);
+}
+
+.section-ai {
+    background: linear-gradient(135deg, #f4d03f, #f1c40f);
+}
+
+.section-about {
+    background: linear-gradient(135deg, #e67e22, #d35400);
+}
+
+.section-contact {
+    background: linear-gradient(135deg, #922b21, #c0392b);
+}
+
+.section-content {
+    width: min(980px, 100%);
+}
+
+h1,
+h2,
+h3,
+p,
+label,
+li {
+    color: #ffffff;
+}
+
 h1 {
-    font-size: 2.8rem;
-    margin-bottom: 20px;
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    margin: 0 0 20px;
 }
 
 h2 {
-    margin-top: 60px;
+    margin-top: 50px;
     font-size: 1.5rem;
 }
 
 p {
-    max-width: 760px;
+    max-width: 800px;
     font-size: 1.05rem;
 }
 
 .pillars {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 40px;
-    margin-top: 40px;
+    gap: 28px;
+    margin-top: 32px;
 }
 
 .pillar {
-    border-top: 2px solid #eee;
+    border-top: 2px solid rgba(255, 255, 255, 0.45);
     padding-top: 20px;
 }
 
-.email a {
-    color: #0057ff;
-    text-decoration: none;
-    font-weight: 500;
-}
-
-.email a:hover {
-    text-decoration: underline;
-}
-.language-switch {
-    margin-left: 24px;
-}
-
-#language-select {
-    border: 1px solid #d9d9d9;
-    border-radius: 6px;
-    background: #ffffff;
-    color: #0B1F33;
-    font-size: 0.95rem;
-    padding: 6px 10px;
-}
-
-.visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    border: 0;
-}
 .contact-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 36px;
     margin-top: 24px;
 }
-
-.contact-details h2,
-.contact-form-wrap h2 {
-    margin-top: 24px;
-}
-
-.address-card {
-    border-top: 2px solid #eee;
-    padding-top: 12px;
-    margin-top: 14px;
-}
-
 
 .location-list {
     list-style: none;
@@ -193,7 +181,7 @@ p {
 
 .location-list .address-card {
     position: relative;
-    border-top: 2px solid #eee;
+    border-top: 2px solid rgba(255, 255, 255, 0.45);
     padding-top: 12px;
     margin-top: 16px;
     padding-left: 34px;
@@ -209,22 +197,11 @@ p {
     background: url('../images/bdslab-grid.svg') no-repeat center / contain;
 }
 
-.address-card h3 {
-    margin: 0 0 6px;
-}
-
-.address-card p {
-    margin: 4px 0;
-}
-
+.email a,
 .address-card a {
-    color: #0057ff;
-    text-decoration: none;
-    font-weight: 500;
-}
-
-.address-card a:hover {
+    color: #ffffff;
     text-decoration: underline;
+    font-weight: 600;
 }
 
 #contact-form {
@@ -232,29 +209,28 @@ p {
     gap: 10px;
 }
 
-#contact-form label {
-    font-weight: 600;
-}
-
 #contact-form input,
 #contact-form textarea {
     width: 100%;
-    border: 1px solid #d9d9d9;
+    border: 1px solid rgba(255, 255, 255, 0.4);
     border-radius: 6px;
     padding: 10px 12px;
     font: inherit;
     box-sizing: border-box;
+    background: rgba(0, 0, 0, 0.2);
+    color: #fff;
 }
 
-#contact-form textarea {
-    resize: vertical;
+#contact-form input::placeholder,
+#contact-form textarea::placeholder {
+    color: rgba(255, 255, 255, 0.8);
 }
 
 #contact-form button {
     width: fit-content;
     border: 0;
     border-radius: 6px;
-    background: #0057ff;
+    background: rgba(0, 0, 0, 0.35);
     color: #fff;
     padding: 10px 16px;
     font: inherit;
@@ -262,25 +238,77 @@ p {
     cursor: pointer;
 }
 
-#contact-form button:disabled {
-    opacity: 0.7;
-    cursor: wait;
-}
-
-#contact-form-status {
-    margin: 4px 0 0;
-    font-weight: 500;
-}
-
 #contact-form-status.status-success {
-    color: #187545;
+    color: #e8ffec;
 }
 
 #contact-form-status.status-error {
-    color: #aa2f2f;
+    color: #ffe8e8;
 }
 
 #contact-form-status a {
     color: inherit;
     text-decoration: underline;
+}
+
+footer {
+    padding: 20px;
+    background: #0f0f0f;
+}
+
+.footer-inner {
+    max-width: 1040px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+.footer-inner p {
+    margin: 0;
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+@media (max-width: 900px) {
+    .header-inner {
+        padding: 0 6%;
+        flex-wrap: wrap;
+    }
+
+    nav ul {
+        flex-wrap: wrap;
+        gap: 12px 18px;
+    }
+
+    .language-switch {
+        margin-left: 0;
+    }
+}
+
+@media (max-width: 640px) {
+    .logo-header,
+    .logo-footer {
+        height: 32px;
+    }
+
+    .section {
+        padding: 110px 6% 60px;
+    }
+
+    p {
+        font-size: 1rem;
+    }
 }

--- a/index.html
+++ b/index.html
@@ -4,23 +4,22 @@
     <meta charset="UTF-8">
     <title>BDS Lab — Business Decision Systems</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
     <meta name="description"
           content="BDS Lab designs automation and AI-supported business decision systems for complex and regulated environments.">
     <link rel="stylesheet" href="css/main.css">
 </head>
-
 <body>
-
-<header>
+<header class="site-nav" id="site-nav">
     <div class="header-inner">
-        <img src="images/bdslab-main.png" alt="BDS Lab" class="logo logo-header">
-        <nav>
-            <a href="#home" data-page="home" data-key="navHome">Home</a>
-            <a href="#automation" data-page="automation" data-key="navAutomation">Automation & Robotics</a>
-            <a href="#ai-tools" data-page="ai-tools" data-key="navAiTools">AI Tools</a>
-            <a href="#about" data-page="about" data-key="navAbout">About</a>
-            <a href="#contact" data-page="contact" data-key="navContact">Contact</a>
+        <img src="images/bdslab.svg" alt="BDS Lab" class="logo logo-header">
+        <nav aria-label="Primary navigation">
+            <ul>
+                <li><a href="#home" data-key="navHome">Home</a></li>
+                <li><a href="#automation" data-key="navAutomation">Automation & Robotics</a></li>
+                <li><a href="#ai" data-key="navAiTools">AI Tools</a></li>
+                <li><a href="#about" data-key="navAbout">About</a></li>
+                <li><a href="#contact" data-key="navContact">Contact</a></li>
+            </ul>
         </nav>
         <div class="language-switch">
             <label for="language-select" class="visually-hidden">Language</label>
@@ -32,11 +31,31 @@
     </div>
 </header>
 
-<main id="app"></main>
+<main>
+    <section id="home" class="section section-home">
+        <div class="section-content" data-section-content="home"></div>
+    </section>
+
+    <section id="automation" class="section section-automation">
+        <div class="section-content" data-section-content="automation"></div>
+    </section>
+
+    <section id="ai" class="section section-ai">
+        <div class="section-content" data-section-content="ai"></div>
+    </section>
+
+    <section id="about" class="section section-about">
+        <div class="section-content" data-section-content="about"></div>
+    </section>
+
+    <section id="contact" class="section section-contact">
+        <div class="section-content" data-section-content="contact"></div>
+    </section>
+</main>
 
 <footer>
     <div class="footer-inner">
-        <img src="images/bdslab-main.png" alt="BDS Lab" class="logo logo-footer">
+        <img src="images/bdslab.svg" alt="BDS Lab" class="logo logo-footer">
         <p>© 2026 · BDS Lab · Business Decision Systems</p>
     </div>
 </footer>

--- a/js/pages.js
+++ b/js/pages.js
@@ -111,10 +111,10 @@ const translations = {
     }
 };
 
-function getPageTemplate(page, language) {
+function getSectionTemplate(section, language) {
     const t = translations[language] || translations.en;
 
-    const pages = {
+    const sections = {
         home: `
           <h1><img src="images/bdslab-grid.svg" alt="BDS Lab" height="30"> ${t.homeTitle}</h1>
 
@@ -135,21 +135,19 @@ function getPageTemplate(page, language) {
               <p>${t.homePillarTwoBody}</p>
             </div>
 
-
-             <div class="pillar">
+            <div class="pillar">
               <h3>${t.homePillarThreeTitle}</h3>
               <p>${t.homePillarThreeBody}</p>
             </div>
           </div>
 
-          <section class="content-section"> 
+          <section class="content-section">
             <h2>${t.homePracticeTitle}</h2>
             <p>${t.homePracticeBodyOne}</p>
             <p>${t.homePracticeBodyTwo}</p>
             <p>${t.homePracticeBodyThree}</p>
           </section>
         `,
-
 
         automation: `
           <h1><img src="images/bdslab-grid.svg" alt="BDS Lab" height="30"> ${t.automationTitle}</h1>
@@ -161,7 +159,7 @@ function getPageTemplate(page, language) {
           <p>${t.automationBodyThree}</p>
         `,
 
-        "ai-tools": `
+        ai: `
           <h1><img src="images/bdslab-grid.svg" alt="BDS Lab" height="30"> ${t.aiToolsTitle}</h1>
 
           <p>${t.aiToolsBodyOne}</p>
@@ -233,5 +231,5 @@ function getPageTemplate(page, language) {
         `
     };
 
-    return pages[page] || pages.home;
+    return sections[section] || sections.home;
 }


### PR DESCRIPTION
### Motivation
- Consolidate the multi-page site into a single-page, vertical-scroll layout so navigation uses in-page anchors and no full-page reloads are required.
- Make each former page a full-screen `section` with distinct class-based gradient backgrounds to support future image/parallax/video backgrounds.
- Preserve existing multilingual content and contact form behavior while enabling smooth scrolling, active-nav state, and subtle visual nav changes on scroll.
- No external skills were required or used for this change.

### Description
- Replaced the previous page-swapping shell with a single-file structure in `index.html` that includes five in-place sections: `#home`, `#automation`, `#ai`, `#about`, and `#contact` and a fixed top navigation using anchor links.
- Implemented `getSectionTemplate` in `js/pages.js` and updated `js/app.js` to `renderSections` (render all section content in-place), rewire language switching to re-render sections, and keep the contact form wiring using `setupContactForm`.
- Added scroll behavior and UI enhancements in `js/app.js` using an `IntersectionObserver` to toggle `.visible` and highlight the active nav link, and added `setupScrolledNavState` to toggle a `.scrolled` nav class on scroll.
- Updated `css/main.css` to enable `scroll-behavior: smooth`, `scroll-snap-type: y mandatory`, full-height `.section` blocks with centered content, fade-in animation (`.section.visible`), and class-based gradient backgrounds for each section; also adjusted responsive and nav styles and replaced image references to `images/bdslab.svg`.

### Testing
- Performed a syntax check on the scripts with `node --check js/app.js && node --check js/pages.js`, which completed successfully.
- Launched a local static server with `python -m http.server 4173` and captured a full-page screenshot using Playwright to visually validate the single-page layout (artifact: `artifacts/single-page-layout.png`).
- Verified that language switching re-renders section content and that the contact form remains wired via the `setupContactForm` path using the rendered section markup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c6cb629248322a284d4cd666fd94a)